### PR TITLE
feat: Omit local ID fields by default

### DIFF
--- a/test/NodeType.test.js
+++ b/test/NodeType.test.js
@@ -52,7 +52,9 @@ describe('NodeType', () => {
       httpApi: new TestHttpApi(),
     };
 
-    const { nodeField, nodesField, ...rest } = createNodeType();
+    const { nodeField, nodesField, ...rest } = createNodeType({
+      localIdFieldMode: 'deprecated',
+    });
     ({ NodeType, createResolve } = rest);
 
     class WidgetResource extends TestHttpResource {


### PR DESCRIPTION
Allow including them, possibly with deprecation, as non-default options.