### PR TITLE
Pass down optional args on HttpResource.get()

### DIFF
--- a/src/resources/HttpResource.js
+++ b/src/resources/HttpResource.js
@@ -28,8 +28,8 @@ export default class HttpResource<TApi: HttpApi = HttpApi> extends Resource<
     this._endpoint = endpoint;
   }
 
-  get(id?: string): ?Object | Promise<?Object> {
-    return this.api.get(this.getPath(id));
+  get(id?: string, args?: Args): ?Object | Promise<?Object> {
+    return this.api.get(this.getPath(id), args);
   }
 
   getConnection(args: Args) {

--- a/src/resources/Resource.js
+++ b/src/resources/Resource.js
@@ -1,5 +1,7 @@
 /* @flow */
 
+import type { Args } from '../api/HttpApi';
+
 export default class Resource<TContext> {
   context: TContext;
 
@@ -9,7 +11,7 @@ export default class Resource<TContext> {
   }
 
   // eslint-disable-next-line no-unused-vars
-  get(id: string): ?Object | Promise<?Object> {
+  get(id: string, args?: Args): ?Object | Promise<?Object> {
     throw new Error('not implemented');
   }
 


### PR DESCRIPTION
`Args` can be passed down, no?

I guess no one needed this before...?