### PR TITLE
chore: clean build output before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "clean": "node -e \"require('fs').rmSync('lib',{ recursive:true, force:true })\"",
+    "build": "yarn run clean && tsc",
     "prepublishOnly": "yarn run build",
     "tdd": "yarn testonly --watch",
     "test": "yarn lint && yarn typecheck && yarn testonly",


### PR DESCRIPTION
Add a dedicated clean step and ensure build starts from a fresh output directory.

- Add `clean` script to remove `lib/`
- Update `build` to run `clean` before `tsc`

No change to module format (still ESM-only) or published entrypoints.